### PR TITLE
Use locally bundled fonts for UI and PDF generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,22 +125,22 @@
                 <label>Header — Fat Rounded (Rubik Mono One)</label>
                 <input id="fontHdr" type="file" accept=".ttf" />
                 <div id="fontHdrStatus" class="note">
-                  Will load via CDN unless you upload a TTF here
-                  <span class="status-dot warn"></span>
+                  Bundled locally. Upload a TTF to override.
+                  <span class="status-dot ok"></span>
                 </div>
               </div>
               <div class="group">
                 <label>Body — Thin Monospace (DM Mono Light)</label>
                 <input id="fontBody" type="file" accept=".ttf" />
                 <div id="fontBodyStatus" class="note">
-                  Will load via CDN unless you upload a TTF here
-                  <span class="status-dot warn"></span>
+                  Bundled locally. Upload a TTF to override.
+                  <span class="status-dot ok"></span>
                 </div>
               </div>
             </div>
             <div class="note">
-              If both CDN and uploads fail, I'll fall back to Courier (headers)
-              and Helvetica (body).
+              If local fonts are missing or uploads fail, I'll fall back to
+              Courier (headers) and Helvetica (body).
             </div>
           </fieldset>
         </div>

--- a/script.js
+++ b/script.js
@@ -690,26 +690,18 @@ async function fetchFirst(urls, timeoutMs = 8000) {
 
 const FONT_TARGETS = {
   hdr: {
-    name: 'RubikMonoOne',
-    vfs: 'RubikMonoOne.ttf',
+    name: 'RubikFlex',
+    vfs: 'RubikFlex.ttf',
     input: 'fontHdr',
     status: 'fontHdrStatus',
-    urls: [
-      'https://cdn.jsdelivr.net/npm/@fontsource/rubik-mono-one@5.0.0/files/rubik-mono-one-latin-400-normal.ttf',
-      'https://fonts.gstatic.com/s/rubikmonoone/v17/UqyJK8kPP3hjw6ANTdfRk9YSN-8wRqQrc_j9.ttf',
-      'https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/rubikmonoone/RubikMonoOne-Regular.ttf',
-    ],
+    urls: ['fonts/Rubik/Rubik-VariableFont_wght.ttf'],
   },
   body: {
     name: 'DMMono-Light',
     vfs: 'DMMono-Light.ttf',
     input: 'fontBody',
     status: 'fontBodyStatus',
-    urls: [
-      'https://cdn.jsdelivr.net/npm/@fontsource/dm-mono@5.0.0/files/dm-mono-latin-300-normal.ttf',
-      'https://fonts.gstatic.com/s/dmmono/v14/aFTU7PB1QTsUX8KYthqQBK0ReMw.ttf',
-      'https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/dmmono/DMMono-Light.ttf',
-    ],
+    urls: ['fonts/DM_Mono/DMMono-Light.ttf'],
   },
 }
 
@@ -755,14 +747,14 @@ async function ensureFonts() {
           FONT_TARGETS.hdr.vfs,
           window.__pdfFonts.hdr
         )
-        setStatus('hdr', 'ok', 'Embedded')
+        setStatus('hdr', 'ok', 'Embedded override')
       } else {
         await addFromUrls(
           FONT_TARGETS.hdr.name,
           FONT_TARGETS.hdr.vfs,
           FONT_TARGETS.hdr.urls
         )
-        setStatus('hdr', 'ok', 'CDN loaded')
+        setStatus('hdr', 'ok', 'Local bundled font')
       }
       if (window.__pdfFonts.body) {
         await addFromB64(
@@ -770,14 +762,14 @@ async function ensureFonts() {
           FONT_TARGETS.body.vfs,
           window.__pdfFonts.body
         )
-        setStatus('body', 'ok', 'Embedded')
+        setStatus('body', 'ok', 'Embedded override')
       } else {
         await addFromUrls(
           FONT_TARGETS.body.name,
           FONT_TARGETS.body.vfs,
           FONT_TARGETS.body.urls
         )
-        setStatus('body', 'ok', 'CDN loaded')
+        setStatus('body', 'ok', 'Local bundled font')
       }
       return {
         hdr: FONT_TARGETS.hdr.name,

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,37 @@
 /* TECHNICAL INVOICE GENERATOR - STYLESHEET */
 
 /* Site UI font (PDF uses embedded fonts below) */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&display=swap');
+@font-face {
+  font-family: 'DM Mono';
+  src: url('./fonts/DM_Mono/DMMono-Light.ttf') format('truetype');
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'DM Mono';
+  src: url('./fonts/DM_Mono/DMMono-Regular.ttf') format('truetype');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'DM Mono';
+  src: url('./fonts/DM_Mono/DMMono-Medium.ttf') format('truetype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rubik Flex';
+  src: url('./fonts/Rubik/Rubik-VariableFont_wght.ttf') format('truetype');
+  font-weight: 100 900;
+  font-style: normal;
+  font-display: swap;
+}
 
 :root {
   --ui-bg-light: #fff;
@@ -70,7 +100,7 @@ html[data-theme='dark'] .themed {
 }
 
 body {
-  font-family: 'IBM Plex Mono', monospace;
+  font-family: 'DM Mono', monospace;
   font-size: 11px;
   line-height: 1.35;
 }
@@ -98,6 +128,7 @@ body {
 }
 
 .header h1 {
+  font-family: 'Rubik Flex', 'DM Mono', monospace;
   font-weight: 700;
   letter-spacing: 2px;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- replace Google Fonts import with local DM Mono and Rubik font-face declarations for the UI
- update PDF font loader to use bundled font files instead of remote CDNs and refresh status text
- clarify UI copy to indicate local fonts with graceful fallbacks

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cc597b28288333a58fe5d2238e2f6a